### PR TITLE
Some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
 *.pyc
+*.egg-info
+*.swp
+build/
+dist/

--- a/flint/project.py
+++ b/flint/project.py
@@ -37,6 +37,8 @@ class Project(object):
                 matched_unit = self.search_units(unit, utype, name)
                 if matched_unit:
                     break
+            if matched_unit:
+                break
         return matched_unit
 
     # TODO: *paths is generally a bad idea for a public API.  I am only using
@@ -80,7 +82,7 @@ class Project(object):
             self.files.append(f90file)
 
         if len(skipped_items) > 0:
-            print("WARNING: Item(s) were skipped")
             if self.verbose:
+                print("WARNING: Item(s) were skipped")
                 for item in skipped_items:
                     print(">",item)

--- a/flint/project.py
+++ b/flint/project.py
@@ -13,26 +13,74 @@ class Project(object):
 
         self.directories = []
 
+    # Recursive hunt for a unit matching utype and name
+    def search_units(self, unit, utype, name):
+        if unit.name == name and unit.utype == utype:
+            return unit
+        if unit.blocks:
+            for block in unit.blocks:
+                match = self.search_units(block, utype, name)
+                if match:
+                    return match
+        if unit.subprograms:
+            for subprog in unit.subprograms:
+                match = self.search_units(subprog, utype, name)
+                if match:
+                    return match
+        return None
+
+    # This returns the matching Unit or None if not found.
+    def find_member(self, utype, name):
+        matched_unit = None
+        for proj_file in self.files:
+            for unit in proj_file.units:
+                matched_unit = self.search_units(unit, utype, name)
+                if matched_unit:
+                    break
+        return matched_unit
+
     # TODO: *paths is generally a bad idea for a public API.  I am only using
     #   it here to get sensible output in my MOM6 tests.
     # TODO: `exclude` may prove more useful here.
-    def parse(self, *paths):
+    # Keep track of skipped items
+    # Because *input_items is an iterable, you can pass a single file or many
+    # single files and directories.  Make a pathway for files and directories.
+    # TODO: detect file/directory globs?
+    def parse(self, *input_items):
+        skipped_items = []
         filepaths = []
-        for path in paths:
-            assert os.path.isdir(path)
-            self.path = path
+        for input_item in input_items:
+            if os.path.isdir(input_item):
+                self.path = input_item
 
-            for root, dirs, files in os.walk(self.path):
-                self.directories.append(root)
+                for root, dirs, files in os.walk(self.path):
+                    self.directories.append(root)
 
-                for fname in files:
-                    fpath = os.path.join(root, fname)
-                    if os.path.splitext(fname)[1] in ('.f90', '.F90'):
-                        filepaths.append(fpath)
-                    else:
-                        print('SKIP file: {}'.format(fpath))
+                    for fname in files:
+                        fpath = os.path.join(root, fname)
+                        if os.path.splitext(fname)[1] in ('.f90', '.F90'):
+                            filepaths.append(fpath)
+                        else:
+                            skipped_items.append(fpath)
+            elif os.path.isfile(input_item):
+                filepaths.append(input_item)
 
         for fpath in filepaths:
+            self.path = fpath
             f90file = Source(project=self, verbose=self.verbose)
-            f90file.parse(fpath)
+            try:
+                f90file.parse(path=fpath)
+            except IOError:
+                # In case of IO error, consider this a skipped file
+                skipped_items.append(fpath)
+            except:
+                # Propogate other errors up to the program
+                print("Unexpected error:", sys.exc_info()[0])
+                raise
             self.files.append(f90file)
+
+        if len(skipped_items) > 0:
+            print("WARNING: Item(s) were skipped")
+            if self.verbose:
+                for item in skipped_items:
+                    print(">",item)

--- a/flint/source.py
+++ b/flint/source.py
@@ -93,7 +93,8 @@ class Source(object):
         tokenizer = Tokenizer()
         line_number = 0
         src_lines = []
-        print('{} ({})'.format(self.path, self.abspath))
+        if self.verbose:
+            print('{} ({})'.format(self.path, self.abspath))
 
         # TODO: Settle on name, move to __init__
         self.stop_parsing = False
@@ -193,8 +194,9 @@ class Source(object):
             try:
                 self.defines.pop(identifier)
             except KeyError:
-                print('flint: warning: unset identifier {} was never '
-                      'defined.'.format(identifier))
+                if self.verbose:
+                    print('flint: warning: unset identifier {} was never '
+                          'defined.'.format(identifier))
 
         # TODO
         #elif directive == 'if':
@@ -248,9 +250,10 @@ class Source(object):
                 self.tokenize(path=inc_path, report=inc_report)
                 self.inc_reports[inc_path] = inc_report
             else:
-                print('flint: Include file {} not found; skipping.'
-                      ''.format(inc_fname))
-
+                if self.verbose:
+                    print('flint: Include file {} not found; skipping.'
+                          ''.format(inc_fname))
         else:
-            print('flint: unsupported preprocess directive: {}'
-                  ''.format(line))
+            if self.verbose:
+                print('flint: unsupported preprocess directive: {}'
+                      ''.format(line))

--- a/flint/source.py
+++ b/flint/source.py
@@ -41,6 +41,7 @@ class Source(object):
         # Resolve filepaths
         if os.path.isabs(path):
             self.abspath = path
+            self.path = path
 
             if self.project:
                 root_path = self.project.path
@@ -58,10 +59,11 @@ class Source(object):
             else:
                 self.abspath = os.path.abspath(path)
 
-        src_lines = self.tokenize()
+        (src_lines, flines) = self.tokenize()
 
         # NOTE: Would be great to integrate this with self.tokenize()
-        flines = FortLines(src_lines)
+        # Kinda moved into tokenize
+        #flines = FortLines(src_lines)
 
         for line in flines:
             try:
@@ -172,7 +174,7 @@ class Source(object):
 
         report.check_keyword_case()
 
-        return src_lines
+        return (src_lines, FortLines(src_lines))
 
     def preprocess(self, line):
         words = line.strip().split(None, 2)

--- a/flint/units/unit.py
+++ b/flint/units/unit.py
@@ -276,12 +276,15 @@ class Unit(object):
                 tok = next(tokens)
 
             # Attributes
+            var_attributes = []
             while tok == ',':
                 tok = next(tokens)
                 attr = tok
+                var_attributes.append(attr)
                 if attr in ('dimension', 'intent'):
                     tok = next(tokens)
                     assert tok == '('
+                    var_attributes.append(tok)
                     par_count = 1
                     while par_count > 0:
                         tok = next(tokens)
@@ -289,6 +292,7 @@ class Unit(object):
                             par_count += 1
                         elif tok == ')':
                             par_count -= 1
+                        var_attributes.append(tok)
                 tok = next(tokens)
 
             if tok == '::':
@@ -324,6 +328,8 @@ class Unit(object):
                     lines.prior_var.doc.docstring += '\n'.join(prior_docs)
 
                 var.doc.docstring = doc
+                if var_attributes:
+                    var.attributes = var_attributes
                 lines.docstrings = []
                 lines.prior_var = var
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+long_description="Flint is a Fortran lint tool. It is not yet working, but can currently do some basic tasks. It is currently written as a Python module, but I expect it will use command line tools someday. Flint is not exactly useable at the moment, but it does contain some decent functionality, and has been integrated into a few projects at a very basic level. Currently, tokenization is good, and several very large projects are correctly tokenized. But analysis is still rather weak, and would benefit from feedback from any brave users."
+
+setuptools.setup(
+    name="flint",
+    version="0.0.1",
+    author="Marshall Ward",
+    author_email="marshal.ward@gmail.com",
+    description="A fortran lint tool",
+    long_description=long_description,
+    url="https://github.com/marshallward/flint",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
This prepares the groundwork to allow flint to be used within sphinx and extension framework.  Flint can ultimately replace the other fortran handling infrastructure currently in use, but for now we will use it to shore up doxygen xml shortcomings.  

Improvements:
- allow Project.parse to take single or list of files or directories.  The ability to parse a single file will be useful for initial work with sphinx.  Path and abspath tracking will need more work.
- add Project.find_member function to allow selection of specific units.  There may be a better way to search the structures.
- moved all print statements under the self.verbose flag
- found a way to move FortLines into the tokenize() routine
- took a stab at populating var.attributes.  These will be needed to fix things up in sphinx.
- added a setup.py stub so the module can be installed via git/requirements.txt

With the unit search, we can pull out a single member:
```
> function eos_domain
!> This subroutine returns a two point integer array indicating the domain of i-indices
!! to work on in EOS calls based on information from a hor_index type
  v> hi hor_index_type ['intent', '(', 'in', ')'] 0 !< The horizontal index structure
  v> halo integer ['optional', 'intent', '(', 'in', ')'] 0 !< The halo size to work on; missing is equivalent to 0.
  v> eosdom integer ['dimension', '(', '2', ')'] 0 !< The index domain that the EOS will work on, taking into account
  v> halo_sz integer [] 0 !! that the arrays inside the EOS routines will start at 1.
```

[Just now noticed that HI is missing that hor_index_type is a type...how to represent that somehow?  At this point, it is not an urgent issue, I just need eosdom for starters.]

Example code:
```
from flint.project import Project
import os, sys

proj = Project(verbose=False)
proj.parse('src/equation_of_state/MOM_EOS.F90')

unit = proj.find_member('function','eos_domain')
if unit:
    print(">",unit.utype,unit.name)
    print(unit.doc.docstring)
    if unit.variables:
        for varb in unit.variables:
            print("  v>",varb.name,varb.type,varb.attributes,varb.refs,varb.doc.docstring)
```

xml support in doxygen-1.8.13 is not functional for our needs.  xml support is good in doxygen-1.8.19, but still falls short.  Flint will help fix those shortcomings with eventual replacement later on.

One shortcoming with the doxygen processor is dealing with fortran functions of this structure:
```
!> This subroutine returns a two point integer array indicating the domain of i-indices
!! to work on in EOS calls based on information from a hor_index type
function EOS_domain(HI, halo) result(EOSdom)
  type(hor_index_type), intent(in)  :: HI    !< The horizontal index structure
  integer,    optional, intent(in)  :: halo  !< The halo size to work on; missing is equivalent to 0.
  integer, dimension(2) :: EOSdom   !< The index domain that the EOS will work on, taking into account
                                    !! that the arrays inside the EOS routines will start at 1.

  ! Local variables
  integer :: halo_sz

  halo_sz = 0 ; if (present(halo)) halo_sz = halo

  EOSdom(1) = HI%isc - (HI%isd-1) - halo_sz
  EOSdom(2) = HI%iec - (HI%isd-1) + halo_sz

end function EOS_domain
```

The xml from doxygen-1.8.19 does not contain enough information for the argument ```result(EOSdom)```.    The only acknowledgement is there is a return argument.  Not even a variable name to fall back on.  There is enough in sphinx to intercept and use the ```<location>``` tag to reprocess the source file through flint and make corrections on the fly.
```
<memberdef kind="function" id="namespacemom__eos_1a782d326108e390902e520efc078e8296" prot="public" static="no" const="no" 
explicit="no" inline="no" virt="non-virtual">
        <type>integer function, dimension(2), public</type>
        <definition>integer function, dimension(2), public mom_eos::eos_domain</definition>
        <argsstring>(HI, halo)</argsstring>
        <name>eos_domain</name>
        <param>
          <type>HI</type>
          <defname>HI</defname>
        </param>
        <param>
          <type>halo</type>
          <defname>halo</defname>
        </param>
        <briefdescription>
<para>This subroutine returns a two point integer array indicating the domain of i-indices to work on in EOS calls based on information from a hor_index type. </para>
        </briefdescription>
        <detaileddescription>
<para><parameterlist kind="param"><parameteritem>
<parameternamelist>
<parametername direction="in">hi</parametername>
</parameternamelist>
<parameterdescription>
<para>The horizontal index structure </para>
</parameterdescription>
</parameteritem>
<parameteritem>
<parameternamelist>
<parametername direction="in">halo</parametername>
</parameternamelist>
<parameterdescription>
<para>The halo size to work on; missing is equivalent to 0. </para>
</parameterdescription>
</parameteritem>
</parameterlist>
<simplesect kind="return"><para>The index domain that the EOS will work on, taking into account that the arrays inside the EOS routines will start at 1. </para>
</simplesect>
</para>
        </detaileddescription>
        <inbodydescription>
        </inbodydescription>
        <location file="/home/cermak/src/MOM6.esmgdocs/src/equation_of_state/MOM_EOS.F90" line="1162" column="1" bodyfile="/home/cermak/src/MOM6.esmgdocs/src/equation_of_state/MOM_EOS.F90" bodystart="1163" bodyend="1175"/>
      </memberdef>
```
