### PR TITLE
Add followlinks parameter to parse()

### DIFF
--- a/flint/__init__.py
+++ b/flint/__init__.py
@@ -9,13 +9,13 @@ from flint.project import Project
 __version__ = '0.0.1'
 
 
-def parse(*paths, includes=None, excludes=None):
+def parse(*paths, includes=None, excludes=None, followlinks=False):
     include_dirs = includes if includes else []
     exclude_dirs = excludes if excludes else []
 
     project = Project()
     project.include_dirs = include_dirs
 
-    project.parse(*paths, excludes=exclude_dirs)
+    project.parse(*paths, excludes=exclude_dirs, followlinks=followlinks)
 
     return project

--- a/flint/project.py
+++ b/flint/project.py
@@ -31,7 +31,7 @@ class Project(object):
 
     # TODO: *paths is generally a bad idea for a public API.  I am only using
     #   it here to get sensible output in my MOM6 tests.
-    def parse(self, *paths, excludes=None):
+    def parse(self, *paths, excludes=None, followlinks=False):
         # Set up the exclusion list
         if excludes:
             exclude_dirs = [os.path.normpath(p) for p in excludes]
@@ -49,7 +49,7 @@ class Project(object):
             assert os.path.isdir(path)
             self.path = path
 
-            for root, dirs, files in os.walk(self.path):
+            for root, dirs, files in os.walk(self.path, followlinks=followlinks):
                 self.directories.append(root)
 
                 # Skip any excluded directories


### PR DESCRIPTION
When testing on MOM6, the files under `src/parameterizations/CVmix` were not being found because CVmix is a symbolic link. This commit fixes that by adding `followlinks` as an option to the `os.walk()` that finds source code.

- Added followlinks (default False) as arguments in two places to pass to os.walk()
- I made it an option and default False on the basis that the docs for `os.walk()` have a note saying "Be aware that setting followlinks to True can lead to infinite recursion if a link points to a parent directory of itself. [walk()](https://docs.python.org/3/library/os.html#os.walk) does not keep track of the directories it visited already."

